### PR TITLE
Fixes updates

### DIFF
--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: net-exporter
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
If you don't set rolling update, it uses ondelete, which means pods won't roll automatically on update