### PR TITLE
Adds templating for namespace

### DIFF
--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -2,7 +2,7 @@ kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
   name: net-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: net-exporter
 spec:

--- a/helm/net-exporter-chart/templates/rbac.yaml
+++ b/helm/net-exporter-chart/templates/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: net-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: net-exporter
 rules:
@@ -19,13 +19,13 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: net-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: net-exporter
 subjects:
 - kind: ServiceAccount
   name: net-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
 roleRef:
   kind: Role
   name: net-exporter

--- a/helm/net-exporter-chart/templates/service-account.yaml
+++ b/helm/net-exporter-chart/templates/service-account.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: net-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: net-exporter

--- a/helm/net-exporter-chart/templates/service.yaml
+++ b/helm/net-exporter-chart/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: net-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: net-exporter
   annotations:

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -1,0 +1,1 @@
+namespace: monitoring


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3711

On control planes, we're deploying to the namespace `monitoring`. On tenant clusters, we want to deploy to `kube-system`. This PR adds support for templating the namespace, setting `monitoring` as the default.