### PR TITLE
Fix SHA templating when publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
         root: .
         paths:
         - ./architect
+        - ./net-exporter
 
   e2eTestBasic:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
         root: .
         paths:
         - ./architect
-        - ./net-exporter
 
   e2eTestBasic:
     environment:
@@ -69,14 +68,6 @@ jobs:
         at: .
 
     - run: ./architect deploy
-
-  publish_to_stable:
-    machine: true
-    steps:
-    - checkout
-
-    - attach_workspace:
-        at: .
 
     - run:
         name: Publish to stable
@@ -102,10 +93,3 @@ workflows:
               only: master
           requires:
           - e2eTestBasic
-
-      - publish_to_stable:
-          filters:
-            branches:
-              only: master
-          requires:
-          - deploy


### PR DESCRIPTION
Templating only get executed during `build` and `deploy` jobs.
Publish after deploy so we still have the templating done.