### PR TITLE
Increase network dial timeout to 10 seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	{
 		c := network.Config{
 			Dialer: &net.Dialer{
-				Timeout: 5 * time.Second,
+				Timeout: 10 * time.Second,
 			},
 			KubernetesClient: kubernetesClient,
 			Logger:           logger,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5310

In some installations, the 5 second timeout is just a _little_
too extreme, so doubling it to cover these installations with
slightly slower networks.