### PR TITLE
Fixes missing registration for error metrics

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -62,6 +62,21 @@ func New(config Config) (*Collector, error) {
 		}
 	}
 
+	errorCount := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(namespace, "", "error_total"),
+		Help: "Total number of internal errors.",
+	})
+	resolveErrorCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(namespace, "", "resolve_error_total"),
+			Help: "Total number of errors resolving hosts.",
+		},
+		[]string{"host"},
+	)
+
+	prometheus.MustRegister(errorCount)
+	prometheus.MustRegister(resolveErrorCount)
+
 	collector := &Collector{
 		logger: config.Logger,
 
@@ -75,17 +90,8 @@ func New(config Config) (*Collector, error) {
 			nil,
 		),
 
-		errorCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName(namespace, "", "error_total"),
-			Help: "Total number of internal errors.",
-		}),
-		resolveErrorCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: prometheus.BuildFQName(namespace, "", "resolve_error_total"),
-				Help: "Total number of errors resolving hosts.",
-			},
-			[]string{"host"},
-		),
+		errorCount:        errorCount,
+		resolveErrorCount: resolveErrorCount,
 	}
 
 	return collector, nil

--- a/network/network.go
+++ b/network/network.go
@@ -84,6 +84,21 @@ func New(config Config) (*Collector, error) {
 		}
 	}
 
+	errorCount := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(namespace, "", "error_total"),
+		Help: "Total number of internal errors.",
+	})
+	dialErrorCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(namespace, "", "dial_error_total"),
+			Help: "Total number of errors dialing hosts.",
+		},
+		[]string{"host"},
+	)
+
+	prometheus.MustRegister(errorCount)
+	prometheus.MustRegister(dialErrorCount)
+
 	collector := &Collector{
 		dialer:           config.Dialer,
 		kubernetesClient: config.KubernetesClient,
@@ -101,17 +116,8 @@ func New(config Config) (*Collector, error) {
 			nil,
 		),
 
-		errorCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName(namespace, "", "error_total"),
-			Help: "Total number of internal errors.",
-		}),
-		dialErrorCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: prometheus.BuildFQName(namespace, "", "dial_error_total"),
-				Help: "Total number of errors dialing hosts.",
-			},
-			[]string{"host"},
-		),
+		errorCount:     errorCount,
+		dialErrorCount: dialErrorCount,
 	}
 
 	return collector, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6105

We use the register API for the error metrics as it's easier,
and the metrics are constant, but missed that these metrics need
to be registered. Fixed!

With coredns scaled to zero:
```
root@joe-dev-container-bc7569754-ltlxk:/# curl -Ss 10.0.133.5:8000/metrics | grep dns | grep error
# HELP dns_error_total Total number of internal errors.
# TYPE dns_error_total counter
dns_error_total 0
# HELP dns_resolve_error_total Total number of errors resolving hosts.
# TYPE dns_resolve_error_total counter
dns_resolve_error_total{host="giantswarm.io"} 1
dns_resolve_error_total{host="kubernetes.default.svc.cluster.local"} 1
```

With net-exporter endpoint added with a false entry:
```
# HELP network_dial_error_total Total number of errors dialing hosts.
# TYPE network_dial_error_total counter
network_dial_error_total{host="10.0.130.140:8000"} 7
# HELP network_error_total Total number of internal errors.
# TYPE network_error_total counter
network_error_total 0
```