### PR TITLE
Remove basic test requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,5 +96,3 @@ workflows:
           filters:
             branches:
               only: master
-          requires:
-          - e2eTestBasic


### PR DESCRIPTION
I need new channel to be created for new version. 
https://github.com/giantswarm/cluster-operator/pull/517

This will be changed back after kind implementation will be ready