### PR TITLE
Replace role with clusterrole

### DIFF
--- a/helm/net-exporter-chart/templates/rbac.yaml
+++ b/helm/net-exporter-chart/templates/rbac.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: net-exporter
   namespace: {{ .Values.namespace }}
@@ -33,7 +33,7 @@ rules:
   verbs:
   - "use"
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: net-exporter
@@ -45,7 +45,7 @@ subjects:
   name: net-exporter
   namespace: {{ .Values.namespace }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: net-exporter
   labels:
     app: net-exporter


### PR DESCRIPTION
Following https://github.com/giantswarm/net-exporter/pull/44
In control-plane chart installed into monitoring namespace. So init container can't access kube-system namespace with role access. It needs clusterrole. As with previous PR will be rolled back after next released land everywhere