### PR TITLE
Use giantswarm-critical priority class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Tolerations changed to tolerate all taints.
+- Change prioty class to `giantswarm-critical`.
 
 [Unreleased]: https://github.com/giantswarm/net-exporter/compare/v1.2.0...HEAD

--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -23,7 +23,8 @@ spec:
         image: quay.io/giantswarm/namespace-labeler
         securityContext:
           runAsUser: 1000
-          runAsGroup: 1000 
+          runAsGroup: 1000
+      priorityClassName: giantswarm-critical
       containers:
       - name: net-exporter
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -13,7 +13,7 @@ dns:
 image:
   registry: quay.io
   repository: giantswarm/net-exporter
-  tag: [[ .SHA ]]
+  tag: latest
 
 # Control-plane subnets used to generate network policies
 # for managed applications.

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -13,7 +13,7 @@ dns:
 image:
   registry: quay.io
   repository: giantswarm/net-exporter
-  tag: latest
+  tag: [[ .SHA ]]
 
 # Control-plane subnets used to generate network policies
 # for managed applications.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6556
As daemonsets are scheduled with default scheduler starting from 1.12 by default - we can prioritize them as well