### PR TITLE
Make dialer timeout configurable

### DIFF
--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
         - "-namespace={{ .Values.namespace }}"
+        - "-timeout={{ .Values.timeout }}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -10,6 +10,8 @@ dns:
   port: 1053
   label: coredns
 
+timeout: 5
+
 image:
   registry: quay.io
   repository: giantswarm/net-exporter

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -10,7 +10,7 @@ dns:
   port: 1053
   label: coredns
 
-timeout: 5
+timeout: 5s
 
 image:
   registry: quay.io

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ var (
 	namespace string
 	port      string
 	service   string
+	timeout   string
 )
 
 func init() {
@@ -31,6 +33,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", "monitoring", "Namespace of net-exporter service")
 	flag.StringVar(&port, "port", "8000", "Port of net-exporter service")
 	flag.StringVar(&service, "service", "net-exporter", "Name of net-exporter service")
+	flag.StringVar(&timeout, "timeout", "5", "Timeout of the dialer")
 }
 
 func main() {
@@ -90,9 +93,14 @@ func main() {
 
 	var networkCollector prometheus.Collector
 	{
+		t, err := strconv.Atoi(timeout)
+		if err != nil {
+			panic(fmt.Sprintf("%#v\n", err))
+		}
+
 		c := network.Config{
 			Dialer: &net.Dialer{
-				Timeout: 5 * time.Second,
+				Timeout: time.Duration(t) * time.Second,
 			},
 			KubernetesClient: kubernetesClient,
 			Logger:           logger,

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,7 +24,7 @@ var (
 	namespace string
 	port      string
 	service   string
-	timeout   string
+	timeout   time.Duration
 )
 
 func init() {
@@ -33,7 +32,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", "monitoring", "Namespace of net-exporter service")
 	flag.StringVar(&port, "port", "8000", "Port of net-exporter service")
 	flag.StringVar(&service, "service", "net-exporter", "Name of net-exporter service")
-	flag.StringVar(&timeout, "timeout", "5", "Timeout of the dialer")
+	flag.DurationVar(&timeout, "timeout", 5*time.Second, "Timeout of the dialer")
 }
 
 func main() {
@@ -93,14 +92,9 @@ func main() {
 
 	var networkCollector prometheus.Collector
 	{
-		t, err := strconv.Atoi(timeout)
-		if err != nil {
-			panic(fmt.Sprintf("%#v\n", err))
-		}
-
 		c := network.Config{
 			Dialer: &net.Dialer{
-				Timeout: time.Duration(t) * time.Second,
+				Timeout: timeout,
 			},
 			KubernetesClient: kubernetesClient,
 			Logger:           logger,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6641

Make timeout configurable.

In `victory`/`fg72d` the network is a bit flaky and 5 seconds are a bit to strict and cause sporadic timeouts in the TCP dial. 
