### PR TITLE
Increase default timeout

### DIFF
--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -10,7 +10,7 @@ dns:
   port: 1053
   label: coredns
 
-timeout: 5s
+timeout: 10s
 
 image:
   registry: quay.io


### PR DESCRIPTION
Over the weekend Azure experimented a lot of network issues and net-exporter alarms have been triggered all over the Azure installations.

Rather have in place a Confimap and customize the timeout value per TC, it is better to increase it so it will be propagated all over the places and we don't have to do any intervention.