### PR TITLE
Run TCP dial sequentially

### DIFF
--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -10,7 +10,7 @@ dns:
   port: 1053
   label: coredns
 
-timeout: 5s
+timeout: 1s
 
 image:
   registry: quay.io

--- a/network/network.go
+++ b/network/network.go
@@ -166,6 +166,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 		elapsed := time.Since(start)
 
+		time.Sleep(100 * time.Millisecond)
+
 		c.latencyHistogramVec.Add(host, elapsed.Seconds())
 	}
 

--- a/network/network.go
+++ b/network/network.go
@@ -162,6 +162,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 
+		defer conn.Close()
+
 		elapsed := time.Since(start)
 
 		c.latencyHistogramVec.Add(host, elapsed.Seconds())


### PR DESCRIPTION
As discussed over the SIG Infra, we would like to verify the hypothesis that multiple TCP dial on Azure can fail due to the presence of an SYN flood protection. 

The implementation here is pretty simple. Remove the go routing in favour of a simple loop that sequentially goes over `hosts` and dial them