### PR TITLE
Create more verbose output in net-exporter

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -184,7 +184,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			defer conn.Close()
 
 			elapsed := time.Since(start)
-			c.logger.Log("level", "info", "message", "dialing host", "host", host, "scrapeTime", elapsed.Seconds(), "scrapeID", c.scrapeID)
+			c.logger.Log("level", "info", "message", "dialed host", "host", host, "scrapeTime", elapsed.Seconds(), "scrapeID", c.scrapeID)
 
 			c.latencyHistogramVec.Add(host, elapsed.Seconds())
 		}(host)

--- a/network/network.go
+++ b/network/network.go
@@ -140,25 +140,26 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	scrapingStart := time.Now()
 	c.logger.Log("level", "info", "message", "collecting metrics", "scrapeID", c.scrapeID)
 
+	c.logger.Log("level", "info", "message", "collecting service from kubernetes api", "service", c.service, "scrapeID", c.scrapeID)
 	service, err := c.kubernetesClient.CoreV1().Services(c.namespace).Get(c.service, metav1.GetOptions{})
 	if err != nil {
-		c.logger.Log("level", "error", "message", "could not get service from kubernetes api ", "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
+		c.logger.Log("level", "error", "message", "could not collect service from kubernetes api", "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
 		c.errorCount.Inc()
 		return
 	}
 
-	c.logger.Log("level", "info", "message", "collected service", "service ", c.service, "scrapeID", c.scrapeID)
+	c.logger.Log("level", "info", "message", "collected service from kubernetes api", "service ", c.service, "scrapeID", c.scrapeID)
 	hosts = append(hosts, fmt.Sprintf("%v:%v", service.Spec.ClusterIP, c.port))
 
-	c.logger.Log("level", "info", "message", "connecting to kubernetes api to get endpoints", "service", c.service, "scrapeID", c.scrapeID)
+	c.logger.Log("level", "info", "message", "collecting endpoints for service from kubernetes api", "service", c.service, "scrapeID", c.scrapeID)
 	endpoints, err := c.kubernetesClient.CoreV1().Endpoints(c.namespace).Get(c.service, metav1.GetOptions{})
 	if err != nil {
-		c.logger.Log("level", "error", "message", "could not get endpoints from kubernetes api ", "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
+		c.logger.Log("level", "error", "message", "could not collect endpoints for service from kubernetes api ", "service", c.service, "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
 		c.errorCount.Inc()
 		return
 	}
 
-	c.logger.Log("level", "info", "message", "collected endpoints", "service", c.service, "scrapeID", c.scrapeID)
+	c.logger.Log("level", "info", "message", "collected endpoints for service from kubernetes api", "service", c.service, "scrapeID", c.scrapeID)
 	for _, endpointSubset := range endpoints.Subsets {
 		for _, address := range endpointSubset.Addresses {
 			hosts = append(hosts, fmt.Sprintf("%v:%v", address.IP, c.port))
@@ -175,7 +176,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 			start := time.Now()
 
-c.logger.Log("level", "info", "message", "dialing host", "host", host, "scrapeID", c.scrapeID)
+			c.logger.Log("level", "info", "message", "dialing host", "host", host, "scrapeID", c.scrapeID)
 			conn, err := c.dialer.Dial("tcp", host)
 			if err != nil {
 				c.logger.Log("level", "error", "message", "could not dial host", "host", host, "scrapeID", c.scrapeID, "stack", microerror.Stack(err))

--- a/network/network.go
+++ b/network/network.go
@@ -150,7 +150,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.logger.Log("level", "info", "message", "collected service", "service ", c.service, "scrapeID", c.scrapeID)
 	hosts = append(hosts, fmt.Sprintf("%v:%v", service.Spec.ClusterIP, c.port))
 
-	c.logger.Log("level", "info", "message", "connecting to kubernetes api to get endpoints", "service", c.service)
+	c.logger.Log("level", "info", "message", "connecting to kubernetes api to get endpoints", "service", c.service, "scrapeID", c.scrapeID)
 	endpoints, err := c.kubernetesClient.CoreV1().Endpoints(c.namespace).Get(c.service, metav1.GetOptions{})
 	if err != nil {
 		c.logger.Log("level", "error", "message", "could not get endpoints from kubernetes api ", "scrapeID", c.scrapeID, "stack", microerror.Stack(err))

--- a/network/network.go
+++ b/network/network.go
@@ -175,6 +175,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 			start := time.Now()
 
+c.logger.Log("level", "info", "message", "dialing host", "host", host, "scrapeID", c.scrapeID)
 			conn, err := c.dialer.Dial("tcp", host)
 			if err != nil {
 				c.logger.Log("level", "error", "message", "could not dial host", "host", host, "scrapeID", c.scrapeID, "stack", microerror.Stack(err))


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6876

The idea here is just create a more verbose output to identify when the problem is scrapping info for kubernetes api.

We add also some information related to scrapping time to ensure that if it takes too much time to execute the collect function prometheus will also timeout and we can get a target down when the problem is in the third party scrap and not in the net-exporter itself.