### PR TITLE
Avoid 5 dots resolution

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&hosts, "hosts", "giantswarm.io,kubernetes.default.svc.cluster.local", "DNS hosts to resolve")
+	flag.StringVar(&hosts, "hosts", "giantswarm.io.,kubernetes.default.svc.cluster.local.", "DNS hosts to resolve")
 	flag.StringVar(&namespace, "namespace", "monitoring", "Namespace of net-exporter service")
 	flag.StringVar(&port, "port", "8000", "Port of net-exporter service")
 	flag.StringVar(&service, "service", "net-exporter", "Name of net-exporter service")


### PR DESCRIPTION
Avoid the 5 dots issue for the test domains

Catched in the coredns logs
```
2019-10-28T12:39:58.813Z [INFO] 192.168.130.135:41404 - 21953 "A IN kubernetes.default.svc.cluster.local.kube-system.svc.cluster.local. udp 84 false 512" NXDOMAIN qr,aa,rd 177 0.000380505s
```