### PR TITLE
Reduces number of network latency buckets

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -20,7 +20,7 @@ const (
 
 	bucketStart  = 0.001
 	bucketFactor = 2
-	numBuckets   = 15
+	numBuckets   = 5
 )
 
 // Config provides the necessary configuration for creating a Collector.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7389

We currently use 15 exponential buckets for network latency, e.g:
```
# HELP network_latency_seconds Histogram of latency of network dials.
# TYPE network_latency_seconds histogram
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.001"} 152
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.002"} 234
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.004"} 237
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.008"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.016"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.032"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.064"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.128"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.256"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.512"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="1.024"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="2.048"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="4.096"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="8.192"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="16.384"} 238
network_latency_seconds_bucket{host="172.31.193.167:8000",le="+Inf"} 238
```

This is massively overkill. As you can see, most values fall within the first 5 buckets (up to 0.016). I'd expect anything past that to be 'just too damn long'.

Reducing the number of buckets from 15 to 5 reduces the number of time series for network latency by 2/3rds, which should massively help Prometheus load on larger clusters - e.g: `asgard` has 186,536 time series for `network_latency_seconds_bucket`.