### PR TITLE
Changes to ping in ring over mesh

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,0 +1,93 @@
+package network
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_calculateNeighbours(t *testing.T) {
+	testCases := []struct {
+		name               string
+		inputN             int
+		inputIP            string
+		inputAddresses     []string
+		expectedNeighbours []string
+	}{
+		{
+			name:               "case 0",
+			inputN:             1,
+			inputIP:            "127.0.0.1",
+			inputAddresses:     []string{},
+			expectedNeighbours: []string{},
+		},
+		{
+			name:               "case 1",
+			inputN:             1,
+			inputIP:            "127.0.0.1",
+			inputAddresses:     []string{"127.0.0.1"},
+			expectedNeighbours: []string{"127.0.0.1"},
+		},
+		{
+			name:               "case 2",
+			inputN:             1,
+			inputIP:            "127.0.0.1",
+			inputAddresses:     []string{"127.0.0.1", "127.0.0.2"},
+			expectedNeighbours: []string{"127.0.0.2"},
+		},
+		{
+			name:               "case 3",
+			inputN:             1,
+			inputIP:            "127.0.0.2",
+			inputAddresses:     []string{"127.0.0.1", "127.0.0.2"},
+			expectedNeighbours: []string{"127.0.0.1"},
+		},
+		{
+			name:               "case 4",
+			inputN:             2,
+			inputIP:            "127.0.0.1",
+			inputAddresses:     []string{},
+			expectedNeighbours: []string{},
+		},
+		{
+			name:               "case 5",
+			inputN:             2,
+			inputIP:            "127.0.0.1",
+			inputAddresses:     []string{"127.0.0.1"},
+			expectedNeighbours: []string{"127.0.0.1"},
+		},
+		{
+			name:               "case 6",
+			inputN:             2,
+			inputIP:            "127.0.0.1",
+			inputAddresses:     []string{"127.0.0.1", "127.0.0.2"},
+			expectedNeighbours: []string{"127.0.0.2", "127.0.0.1"},
+		},
+		{
+			name:               "case 7",
+			inputN:             2,
+			inputIP:            "127.0.0.2",
+			inputAddresses:     []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+			expectedNeighbours: []string{"127.0.0.3", "127.0.0.1"},
+		},
+		{
+			name:               "case 8",
+			inputN:             2,
+			inputIP:            "127.0.0.4",
+			inputAddresses:     []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"},
+			expectedNeighbours: []string{"127.0.0.1", "127.0.0.2"},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			collector := Collector{}
+			returnedNeighbours := collector.calculateNeighbours(tc.inputN, tc.inputIP, tc.inputAddresses)
+
+			if !cmp.Equal(returnedNeighbours, tc.expectedNeighbours) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expectedNeighbours, returnedNeighbours))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7389

The design of the current net-exporter is problematic in larger clusters. Currently, each net-exporter pings every other net-exporter. This O(n^2) behaviour is problematic in larger clusters, as the cardinality of the metrics increases drastically.

This PR changes the behaviour of net-exporter to ping 'in a ring' instead of in the previous 'mesh' behaviour. This is achieved by fetching the endpoints (as previously), sorting them, and choosing the 'next' n IPs to ping, essentially forming a ring. This changes the complexity to O(n), which is much more desirable, especially in larger clusters.

e.g: without this PR applied, and with 4 net-exporters:
```
Every 2.0s: kubectl -n=kube-system get pod -l=app=net-exporter -o wide                                              Josephs-MacBook-Pro.local: Tue Oct 29 18:34:33 2019

NAME                 READY   STATUS    RESTARTS   AGE   IP                NODE                                          NOMINATED NODE   READINESS GATES
net-exporter-6wm7f   1/1     Running   0          23s   192.168.159.89    ip-10-1-0-48.eu-central-1.compute.internal    <none>           <none>
net-exporter-9c5zz   1/1     Running   0          15s   192.168.144.219   ip-10-1-0-12.eu-central-1.compute.internal    <none>           <none>
net-exporter-9l77j   1/1     Running   0          17s   192.168.15.119    ip-10-1-0-37.eu-central-1.compute.internal    <none>           <none>
net-exporter-hr89k   1/1     Running   0          14s   192.168.122.39    ip-10-1-0-172.eu-central-1.compute.internal   <none>           <none>
```

Each net-exporter exposes metrics for all other net-exporters
```
root@joe-debug-5d8476864b-8k7vk:/# curl -Ss 192.168.159.89:8000/metrics | grep network_latency
# HELP network_latency_seconds Histogram of latency of network dials.
# TYPE network_latency_seconds histogram
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.001"} 1
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.002"} 1
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.004"} 1
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.008"} 1
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.016"} 1
network_latency_seconds_bucket{host="172.31.193.167:8000",le="+Inf"} 2
network_latency_seconds_sum{host="172.31.193.167:8000"} 1.011754388
network_latency_seconds_count{host="172.31.193.167:8000"} 2
network_latency_seconds_bucket{host="192.168.122.39:8000",le="0.001"} 1
network_latency_seconds_bucket{host="192.168.122.39:8000",le="0.002"} 1
network_latency_seconds_bucket{host="192.168.122.39:8000",le="0.004"} 1
network_latency_seconds_bucket{host="192.168.122.39:8000",le="0.008"} 1
network_latency_seconds_bucket{host="192.168.122.39:8000",le="0.016"} 1
network_latency_seconds_bucket{host="192.168.122.39:8000",le="+Inf"} 1
network_latency_seconds_sum{host="192.168.122.39:8000"} 0.000864991
network_latency_seconds_count{host="192.168.122.39:8000"} 1
network_latency_seconds_bucket{host="192.168.144.219:8000",le="0.001"} 1
network_latency_seconds_bucket{host="192.168.144.219:8000",le="0.002"} 1
network_latency_seconds_bucket{host="192.168.144.219:8000",le="0.004"} 1
network_latency_seconds_bucket{host="192.168.144.219:8000",le="0.008"} 1
network_latency_seconds_bucket{host="192.168.144.219:8000",le="0.016"} 1
network_latency_seconds_bucket{host="192.168.144.219:8000",le="+Inf"} 1
network_latency_seconds_sum{host="192.168.144.219:8000"} 0.000646591
network_latency_seconds_count{host="192.168.144.219:8000"} 1
network_latency_seconds_bucket{host="192.168.15.119:8000",le="0.001"} 1
network_latency_seconds_bucket{host="192.168.15.119:8000",le="0.002"} 1
network_latency_seconds_bucket{host="192.168.15.119:8000",le="0.004"} 1
network_latency_seconds_bucket{host="192.168.15.119:8000",le="0.008"} 1
network_latency_seconds_bucket{host="192.168.15.119:8000",le="0.016"} 1
network_latency_seconds_bucket{host="192.168.15.119:8000",le="+Inf"} 1
network_latency_seconds_sum{host="192.168.15.119:8000"} 0.00043754
network_latency_seconds_count{host="192.168.15.119:8000"} 1
network_latency_seconds_bucket{host="192.168.159.89:8000",le="0.001"} 1
network_latency_seconds_bucket{host="192.168.159.89:8000",le="0.002"} 1
network_latency_seconds_bucket{host="192.168.159.89:8000",le="0.004"} 1
network_latency_seconds_bucket{host="192.168.159.89:8000",le="0.008"} 1
network_latency_seconds_bucket{host="192.168.159.89:8000",le="0.016"} 1
network_latency_seconds_bucket{host="192.168.159.89:8000",le="+Inf"} 1
network_latency_seconds_sum{host="192.168.159.89:8000"} 0.000891853
network_latency_seconds_count{host="192.168.159.89:8000"} 1
```
```
root@joe-debug-5d8476864b-8k7vk:/# curl -Ss 192.168.159.89:8000/metrics | grep network_latency | wc -l
42
```

with PR applied, again with 4 net-exporters:
```
Every 2.0s: kubectl -n=kube-system get pod -l=app=net-exporter -o wide                                              Josephs-MacBook-Pro.local: Tue Oct 29 18:29:40 2019

NAME                 READY   STATUS    RESTARTS   AGE     IP                NODE                                          NOMINATED NODE   READINESS GATES
net-exporter-jkfr9   1/1     Running   0          3m52s   192.168.159.88    ip-10-1-0-48.eu-central-1.compute.internal    <none>           <none>
net-exporter-jxd78   1/1     Running   0          4m3s    192.168.15.118    ip-10-1-0-37.eu-central-1.compute.internal    <none>           <none>
net-exporter-sd26s   1/1     Running   0          4m4s    192.168.144.218   ip-10-1-0-12.eu-central-1.compute.internal    <none>           <none>
net-exporter-vqtdh   1/1     Running   0          4m3s    192.168.122.38    ip-10-1-0-172.eu-central-1.compute.internal   <none>           <none>
```

Each net-exporter only exposes latencies for pinging the 'next' 2 net-exporters:
```
root@joe-debug-5d8476864b-8k7vk:/# curl -Ss 192.168.159.88:8000/metrics | grep network_latency
# HELP network_latency_seconds Histogram of latency of network dials.
# TYPE network_latency_seconds histogram
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.001"} 5
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.002"} 6
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.004"} 6
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.008"} 6
network_latency_seconds_bucket{host="172.31.193.167:8000",le="0.016"} 6
network_latency_seconds_bucket{host="172.31.193.167:8000",le="+Inf"} 6
network_latency_seconds_sum{host="172.31.193.167:8000"} 0.004263864000000001
network_latency_seconds_count{host="172.31.193.167:8000"} 6
network_latency_seconds_bucket{host="192.168.122.38:8000",le="0.001"} 2
network_latency_seconds_bucket{host="192.168.122.38:8000",le="0.002"} 6
network_latency_seconds_bucket{host="192.168.122.38:8000",le="0.004"} 6
network_latency_seconds_bucket{host="192.168.122.38:8000",le="0.008"} 6
network_latency_seconds_bucket{host="192.168.122.38:8000",le="0.016"} 6
network_latency_seconds_bucket{host="192.168.122.38:8000",le="+Inf"} 6
network_latency_seconds_sum{host="192.168.122.38:8000"} 0.006626136000000001
network_latency_seconds_count{host="192.168.122.38:8000"} 6
network_latency_seconds_bucket{host="192.168.144.218:8000",le="0.001"} 4
network_latency_seconds_bucket{host="192.168.144.218:8000",le="0.002"} 5
network_latency_seconds_bucket{host="192.168.144.218:8000",le="0.004"} 6
network_latency_seconds_bucket{host="192.168.144.218:8000",le="0.008"} 6
network_latency_seconds_bucket{host="192.168.144.218:8000",le="0.016"} 6
network_latency_seconds_bucket{host="192.168.144.218:8000",le="+Inf"} 6
network_latency_seconds_sum{host="192.168.144.218:8000"} 0.007172451999999999
network_latency_seconds_count{host="192.168.144.218:8000"} 6
```
```
root@joe-debug-5d8476864b-8k7vk:/# curl -Ss 192.168.159.88:8000/metrics | grep network_latency | wc -l
26
```

You can see which neighbours the net-exporter is pinging in the logs as well:
```
...
{"caller":"github.com/giantswarm/net-exporter/network/network.go:243","ip":"192.168.122.40","level":"info","message":"calculated neighbours","neighbours":"192.168.144.220, 192.168.15.120","scrapeID":2,"time":"2019-10-29T18:48:04.308041+00:00"}
...
```

And finally, via Prometheus, you can see that all net-exporters are pinged equally. We do not change the behaviour for the net-exporter service. All net-exporters still ping the service.
```
count(network_latency_seconds_bucket{cluster_id="oby63"}) by (host)
```
<img width="1403" alt="Screen Shot 2019-10-29 at 18 50 14" src="https://user-images.githubusercontent.com/297653/67799267-f6804180-fa7c-11e9-9efc-b71dd3c4f515.png">
