### PR TITLE
Update Changelog since 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] 2019-11-21
+
+### Changed
+
+- Change ping behavior to use a ring instead of a mesh
+- Reduce number of latency buckets from 15 to 5
+- Fix DNS 5 dots issue for test installations
+- Update README to align with other apps
+
+## [1.3.0] 2019-10-24
+
+### Changed
+
+- Add net-exporter to default app catalog
 
 ## [1.2.0] 2019-07-17
 


### PR DESCRIPTION
Add Changelog entries for the 1.3.0 release for default app catalog and the commits since which are intended for 1.4.0 release.

Towards https://github.com/giantswarm/giantswarm/issues/7428