### PR TITLE
Explicitly list all direct dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,15 @@ required = [
 
 [[constraint]]
   branch = "master"
+  name = "github.com/giantswarm/apprclient"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/giantswarm/e2esetup"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/giantswarm/e2etests"
 
 [[constraint]]
   branch = "master"

--- a/helm/net-exporter-chart/templates/psp.yaml
+++ b/helm/net-exporter-chart/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}

--- a/helm/net-exporter/templates/psp.yaml
+++ b/helm/net-exporter/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}


### PR DESCRIPTION
Leftover from https://github.com/giantswarm/net-exporter/pull/70

Without these `dep ensure --update` would panic, would pass only once run in verbose mode.