### PR TITLE
Make image registry configurable for namespace-labeler init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] 2019-11-29
+
+### Changed
+
+- Make image registry configurable for namespace labeler init container.
+
 ## [1.4.0] 2019-11-21
 
 ### Changed

--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -20,14 +20,14 @@ spec:
     spec:
       initContainers:
       - name: label-kube-system-namespace
-        image: quay.io/giantswarm/namespace-labeler
+        image: "{{ .Values.image.registry }}/{{ .Values.namespaceLabeler.image.name }}"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
       priorityClassName: giantswarm-critical
       containers:
       - name: net-exporter
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         args:
         - "-namespace={{ .Values.exporter.namespace }}"
         - "-timeout={{ .Values.timeout }}"

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -15,8 +15,12 @@ timeout: 5s
 
 image:
   registry: quay.io
-  repository: giantswarm/net-exporter
+  name: giantswarm/net-exporter
   tag: "[[ .Version ]]"
+
+namespaceLabeler:
+  image:
+    name: giantswarm/namespace-labeler
 
 # Control-plane subnets used to generate network policies
 # for managed applications.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7773

The quay.io/giantswarm/namespace-labeler image is used by the init container but it wasn't retagged. Found when testing in giraffe to make sure all images are retagged.