### PR TITLE
Add flag to disable DNS TCP check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.6.0] 2020-01-28
+## [Unreleased]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] 2020-01-28
+
+### Changed
+
+- Allow to disable DNS TCP check.
+
 ## [1.5.1] 2020-01-08
 
 ### Changed

--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -44,6 +44,9 @@ spec:
         args:
         - "-namespace={{ .Values.namespace }}"
         - "-timeout={{ .Values.timeout }}"
+        {{ if (.Values.Installation) }}
+        - "-disable-dns-tcp-check={{ .Values.Installation.V1.Monitoring.NetExporter.DisableDNSTCPCheck }}"
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         - "-namespace={{ .Values.namespace }}"
         - "-timeout={{ .Values.timeout }}"
         {{ if (.Values.Installation) }}
-        - "-disable-dns-tcp-check={{ .Values.Installation.V1.Monitoring.NetExporter.DisableDNSTCPCheck }}"
+        - "-disable-dns-tcp-check={{ .Values.Installation.V1.Monitoring.NetExporter.DNSCheck.TCP.Disabled }}"
         {{ end }}
         livenessProbe:
           httpGet:

--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -49,6 +49,9 @@ spec:
         args:
         - "-namespace={{ .Values.exporter.namespace }}"
         - "-timeout={{ .Values.timeout }}"
+        {{ if (.Values.disableDNSTCPCheck) }}
+        - "-disable-dns-tcp-check={{ .Values.disableDNSTCPCheck }}"
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -49,8 +49,8 @@ spec:
         args:
         - "-namespace={{ .Values.exporter.namespace }}"
         - "-timeout={{ .Values.timeout }}"
-        {{ if (.Values.disableDNSTCPCheck) }}
-        - "-disable-dns-tcp-check={{ .Values.disableDNSTCPCheck }}"
+        {{ if (.Values.NetExporter.DNSCheck.TCP.Disabled) }}
+        - "-disable-dns-tcp-check={{ .Values.NetExporter.DNSCheck.TCP.Disabled }}"
         {{ end }}
         livenessProbe:
           httpGet:

--- a/main.go
+++ b/main.go
@@ -21,14 +21,16 @@ import (
 )
 
 var (
-	hosts     string
-	namespace string
-	port      string
-	service   string
-	timeout   time.Duration
+	disableDNSTCPCheck bool
+	hosts              string
+	namespace          string
+	port               string
+	service            string
+	timeout            time.Duration
 )
 
 func init() {
+	flag.BoolVar(&disableDNSTCPCheck, "disable-dns-tcp-check", false, "Disable DNS TCP check")
 	flag.StringVar(&hosts, "hosts", "giantswarm.io.,kubernetes.default.svc.cluster.local.", "DNS hosts to resolve")
 	flag.StringVar(&namespace, "namespace", "monitoring", "Namespace of net-exporter service")
 	flag.StringVar(&port, "port", "8000", "Port of net-exporter service")
@@ -89,7 +91,8 @@ func main() {
 				Net: "udp",
 			},
 
-			Hosts: splitHosts,
+			DisableTCPCheck: disableDNSTCPCheck,
+			Hosts:           splitHosts,
 		}
 
 		dnsCollector, err = dns.New(c)


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

Towards https://github.com/giantswarm/giantswarm/issues/7898

This PR allow to disable DNS TCP check, if it's not supported by the customer installation.