### PR TITLE
Replace namespace-labeler with kubectl

### DIFF
--- a/helm/net-exporter-chart/templates/daemonset.yaml
+++ b/helm/net-exporter-chart/templates/daemonset.yaml
@@ -21,10 +21,16 @@ spec:
       initContainers:
       - name: label-kube-system-namespace
         {{ if (.Values.Installation) }}
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.namespaceLabeler.image.name }}"
+        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.kubectl.image.name }}:{{ .Values.kubectl.image.tag }}"
         {{ else }}
-        image: "{{ .Values.image.registry }}/{{ .Values.namespaceLabeler.image.name }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.kubectl.image.name }}:{{ .Values.kubectl.image.tag }}"
         {{ end }}
+        args:
+          - label
+          - namespace
+          - kube-system
+          - name=kube-system
+          - --overwrite=true
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/helm/net-exporter-chart/templates/rbac.yaml
+++ b/helm/net-exporter-chart/templates/rbac.yaml
@@ -25,6 +25,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - extensions
   resources:

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -17,9 +17,11 @@ image:
   name: giantswarm/net-exporter
   tag: [[ .SHA ]]
 
-namespaceLabeler:
+kubectl:
   image:
-    name: giantswarm/namespace-labeler
+    registry: quay.io
+    name: giantswarm/docker-kubectl
+    tag: 1.16.4
 
 # Control-plane subnets used to generate network policies
 # for managed applications.

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -21,7 +21,7 @@ kubectl:
   image:
     registry: quay.io
     name: giantswarm/docker-kubectl
-    tag: latest
+    tag: 1.16.4
 
 # Control-plane subnets used to generate network policies
 # for managed applications.

--- a/helm/net-exporter-chart/values.yaml
+++ b/helm/net-exporter-chart/values.yaml
@@ -21,7 +21,7 @@ kubectl:
   image:
     registry: quay.io
     name: giantswarm/docker-kubectl
-    tag: 1.16.4
+    tag: latest
 
 # Control-plane subnets used to generate network policies
 # for managed applications.

--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -21,10 +21,16 @@ spec:
       initContainers:
       - name: label-kube-system-namespace
         {{ if (.Values.Installation) }}
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.namespaceLabeler.image.name }}"
+        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.kubectl.image.name }}:{{ .Values.kubectl.image.tag }}"
         {{ else }}
-        image: "{{ .Values.image.registry }}/{{ .Values.namespaceLabeler.image.name }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.kubectl.image.name }}:{{ .Values.kubectl.image.tag }}"
         {{ end }}
+        args:
+          - label
+          - namespace
+          - kube-system
+          - name=kube-system
+          - --overwrite=true
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/helm/net-exporter/templates/rbac.yaml
+++ b/helm/net-exporter/templates/rbac.yaml
@@ -24,6 +24,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - extensions
   resources:

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -22,7 +22,7 @@ kubectl:
   image:
     registry: quay.io
     name: giantswarm/docker-kubectl
-    tag: 1.16.4
+    tag: latest
 
 # Control-plane subnets used to generate network policies
 # for managed applications.

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -18,9 +18,11 @@ image:
   name: giantswarm/net-exporter
   tag: "[[ .Version ]]"
 
-namespaceLabeler:
+kubectl:
   image:
-    name: giantswarm/namespace-labeler
+    registry: quay.io
+    name: giantswarm/docker-kubectl
+    tag: 1.16.4
 
 # Control-plane subnets used to generate network policies
 # for managed applications.

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -22,7 +22,7 @@ kubectl:
   image:
     registry: quay.io
     name: giantswarm/docker-kubectl
-    tag: latest
+    tag: 1.16.4
 
 # Control-plane subnets used to generate network policies
 # for managed applications.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8754
Replacing custom-app with the approach we're using everywhere in case we need to execute anything towards k8s api with kubectl