### PR TITLE
Dont dial deleted pods

### DIFF
--- a/helm/net-exporter-chart/templates/rbac.yaml
+++ b/helm/net-exporter-chart/templates/rbac.yaml
@@ -27,6 +27,13 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
   - extensions
   resources:
   - podsecuritypolicies

--- a/helm/net-exporter/templates/rbac.yaml
+++ b/helm/net-exporter/templates/rbac.yaml
@@ -26,6 +26,13 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
   - extensions
   resources:
   - podsecuritypolicies

--- a/network/network.go
+++ b/network/network.go
@@ -257,8 +257,7 @@ func (c *Collector) podExists(podIP string, podList *v1.PodList) (bool, error) {
 	if errors.IsNotFound(err) {
 		// Pod doesn't exist anymore.
 		return false, nil
-	}
-	if err != nil {
+	} else if err != nil {
 		// Couldn't get the Pod, but for some other reason.
 		return false, err
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -209,6 +209,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				podExists, err := c.podExists(host, pods)
 				if err != nil {
 					c.logger.Log("level", "error", "message", "unable to check if host exists", "host", host, "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
+					return
 				}
 
 				if podExists {

--- a/network/network.go
+++ b/network/network.go
@@ -214,7 +214,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			} else {
 				c.logger.Log("level", "error", "message", "host does not exist", "host", host, "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
 				// TODO: remove this host from future scrapes - how?
-				c.dialErrorCount.WithLabelValues(host).Inc()
 				return
 			}
 

--- a/network/network.go
+++ b/network/network.go
@@ -209,6 +209,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				podExists, err := c.podExists(host, pods)
 				if err != nil {
 					c.logger.Log("level", "error", "message", "unable to check if host exists", "host", host, "scrapeID", c.scrapeID, "stack", microerror.Stack(err))
+					c.dialErrorCount.WithLabelValues(host).Inc()
 					return
 				}
 

--- a/network/network.go
+++ b/network/network.go
@@ -194,7 +194,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		c.errorCount.Inc()
 		return
 	}
-
+	time.Sleep(10 * time.Second)
 	for _, host := range hosts {
 		wg.Add(1)
 

--- a/network/network.go
+++ b/network/network.go
@@ -254,11 +254,11 @@ func (c *Collector) podExists(podIP string, podList *v1.PodList) (bool, error) {
 
 	// Get the Pod to see if it still exists.
 	pod, err := c.k8sClient.CoreV1().Pods(c.namespace).Get(podName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// Pod doesn't exist anymore.
+		return false, nil
+	}
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Pod doesn't exist anymore.
-			return false, nil
-		}
 		// Couldn't get the Pod, but for some other reason.
 		return false, err
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -194,7 +194,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		c.errorCount.Inc()
 		return
 	}
-	time.Sleep(10 * time.Second)
+
 	for _, host := range hosts {
 		wg.Add(1)
 


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/9214
But see also https://github.com/giantswarm/giantswarm/issues/9361

This checks that a Pod exists before dialing it. It should also prevent it from being dialed in the future, but I'm not sure quite how to ensure that.