### PR TITLE
Deploy only when image is in quay and aliyun

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,4 +176,6 @@ workflows:
               only: master
           requires:
           - build
+          - push-net-exporter-to-aliyun
           - push-net-exporter-to-aliyun-master-legacy
+          - push-net-exporter-to-app-catalog


### PR DESCRIPTION
Current CI config deploys after image is present in aliyun. While unusual, it is possible that the push to quay could fail when the push to aliyun succeeds. Don't deploy if this happens. (App catalog currently depends on quay push)