### PR TITLE
Apply commandline values correctly for controlplanes

### DIFF
--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -55,6 +55,17 @@ spec:
         args:
         - "-namespace={{ .Release.Namespace }}"
         - "-timeout={{ .Values.timeout }}"
+        {{ if (.Values.Installation) }}
+        {{ if (.Values.Installation.V1.NetExporter.Hosts) }}
+        - "-hosts={{ .Values.Installation.V1.NetExporter.Hosts }}"
+        {{ end }}
+        {{ if (.Values.Installation.V1.NetExporter.NTPServers) }}
+        - "-ntp-servers={{ .Values.Installation.V1.NetExporter.NTPServers }}"
+        {{ end }}
+        {{ if (.Values.Installation.V1.NetExporter.DNSCheck.TCP.Disabled) }}
+        - "-disable-dns-tcp-check={{ .Values.Installation.V1.NetExporter.DNSCheck.TCP.Disabled }}"
+        {{ end }}
+        {{ end }}
         {{ if (.Values.NetExporter) }}
         {{ if (.Values.NetExporter.Hosts) }}
         - "-hosts={{ .Values.NetExporter.Hosts }}"

--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -56,14 +56,14 @@ spec:
         - "-namespace={{ .Release.Namespace }}"
         - "-timeout={{ .Values.timeout }}"
         {{ if (.Values.Installation) }}
-        {{ if (.Values.Installation.V1.NetExporter.Hosts) }}
-        - "-hosts={{ .Values.Installation.V1.NetExporter.Hosts }}"
+        {{ if (.Values.Installation.V1.Monitoring.NetExporter.Hosts) }}
+        - "-hosts={{ .Values.Installation.V1.Monitoring.NetExporter.Hosts }}"
         {{ end }}
-        {{ if (.Values.Installation.V1.NetExporter.NTPServers) }}
-        - "-ntp-servers={{ .Values.Installation.V1.NetExporter.NTPServers }}"
+        {{ if (.Values.Installation.V1.Monitoring.NetExporter.NTPServers) }}
+        - "-ntp-servers={{ .Values.Installation.V1.Monitoring.NetExporter.NTPServers }}"
         {{ end }}
-        {{ if (.Values.Installation.V1.NetExporter.DNSCheck.TCP.Disabled) }}
-        - "-disable-dns-tcp-check={{ .Values.Installation.V1.NetExporter.DNSCheck.TCP.Disabled }}"
+        {{ if (.Values.Installation.V1.Monitoring.NetExporter.DNSCheck.TCP.Disabled) }}
+        - "-disable-dns-tcp-check={{ .Values.Installation.V1.Monitoring.NetExporter.DNSCheck.TCP.Disabled }}"
         {{ end }}
         {{ end }}
         {{ if (.Values.NetExporter) }}


### PR DESCRIPTION
This fixes an issue where values were not applied correctly from `installations`. This lead to misconfiguration especially on `kvm` installations.

Fixed config on `buffalo`:
```
    Args:
      -namespace=monitoring
      -timeout=5s
      -hosts=giantswarm.io.,kubernetes.default.svc.cluster.local.
      -ntp-servers=192.168.97.33
      -disable-dns-tcp-check=true
```