### PR TITLE
Removes pod listing

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -193,7 +193,12 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 					c.dialErrorCount.WithLabelValues(host).Inc()
 					return
 				}
-				if len(pods.Items) != 1 {
+				if len(pods.Items) == 0 {
+					c.logger.Log("level", "error", "message", fmt.Sprintf("unable to check if host %#q exists, no pods found", host))
+					c.dialErrorCount.WithLabelValues(host).Inc()
+					return
+				}
+				if len(pods.Items) > 1 {
 					c.logger.Log("level", "error", "message", fmt.Sprintf("unable to check if host %#q exists, multiple pods found", host))
 					c.dialErrorCount.WithLabelValues(host).Inc()
 					return


### PR DESCRIPTION
Even with label selector, we still list O(nodes) number pods on each collect. This PR changes to listing O(1) number pods, only when we face a dial error.

<img width="1118" alt="Screenshot 2021-05-06 at 16 30 52" src="https://user-images.githubusercontent.com/297653/117325243-6f3d3680-ae88-11eb-8e80-02ddcf948f89.png">

e.g: on `ginger` (7 nodes), reduces average memory usage from ~25mb to ~13mb. I would expect similar memory usage regardless of cluster size, as well