### PR TITLE
Support k8s dns node cache app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add networkpolicy to allow egress towards `k8s-dns-node-cache-app` endpoints.
+
 ## [1.10.3] - 2021-08-12
 
 ### Changed

--- a/helm/net-exporter/templates/np.yaml
+++ b/helm/net-exporter/templates/np.yaml
@@ -66,12 +66,8 @@ spec:
     - port: {{ .Values.dnscache.port }}
       protocol: TCP
     to:
-    - podSelector:
-        matchLabels:
-          k8s-app: {{ .Values.dnscache.label }}
-      namespaceSelector:
-        matchLabels:
-          name: {{ .Values.dnscache.namespace }}
+    - ipBlock:
+        cidr: {{ .Values.cluster.kubernetes.DNS.IP }}
   - ports:
     - port: 443
       protocol: TCP

--- a/helm/net-exporter/templates/np.yaml
+++ b/helm/net-exporter/templates/np.yaml
@@ -67,7 +67,7 @@ spec:
       protocol: TCP
     to:
     - ipBlock:
-        cidr: {{ .Values.cluster.kubernetes.DNS.IP }}
+        cidr: {{ .Values.cluster.kubernetes.DNS.IP }}/32
   - ports:
     - port: 443
       protocol: TCP

--- a/helm/net-exporter/templates/np.yaml
+++ b/helm/net-exporter/templates/np.yaml
@@ -59,6 +59,19 @@ spec:
       namespaceSelector:
         matchLabels:
           name: {{ .Values.dns.namespace }}
+  # allow DNS resolution through k8s-dns-node-cache-app
+  - ports:
+    - port: {{ .Values.dnscache.port }}
+      protocol: UDP
+    - port: {{ .Values.dnscache.port }}
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          k8s-app: {{ .Values.dnscache.label }}
+      namespaceSelector:
+        matchLabels:
+          name: {{ .Values.dnscache.namespace }}
   - ports:
     - port: 443
       protocol: TCP

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -12,6 +12,11 @@ dns:
   namespace: kube-system
   service: coredns
 
+dnscache:
+  port: 1053
+  label: k8s-dns-node-cache
+  namespace: kube-system
+
 timeout: 5s
 
 image:

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -13,9 +13,12 @@ dns:
   service: coredns
 
 dnscache:
-  port: 1053
-  label: k8s-dns-node-cache
-  namespace: kube-system
+  port: 53
+
+cluster:
+  kubernetes:
+    DNS:
+      IP: 172.31.0.10
 
 timeout: 5s
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/828

this PR adds a new rule to the NetworkPolicy to allow reaching the node local DNS cache endpoint in case the app is deployed