### PR TITLE
Add DNS namespace parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use parameter for CoreDNS namespace (defaulted to kube-system)
+
 ## [1.11.0] - 2022-03-07
 
 ### Added

--- a/helm/net-exporter/templates/daemonset.yaml
+++ b/helm/net-exporter/templates/daemonset.yaml
@@ -24,8 +24,8 @@ spec:
         args:
         - label
         - namespace
-        - kube-system
-        - name=kube-system
+        - {{ .Values.dns.namespace }}
+        - name={{ .Values.dns.namespace }}
         - --overwrite=true
         securityContext:
           runAsUser: 1000
@@ -44,6 +44,7 @@ spec:
           - "-namespace={{ .Release.Namespace }}"
           - "-timeout={{ .Values.timeout }}"
           - "-dns-service={{ .Values.dns.service }}"
+          - "-dns-namespace={{ .Values.dns.namespace }}"
           {{- if (.Values.NetExporter.Hosts) }}
           - "-hosts={{ .Values.NetExporter.Hosts }}"
           {{- end }}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	disableDNSTCPCheck bool
 	hosts              string
 	dnsService         string
+	dnsNamespace       string
 	namespace          string
 	ntpServers         string
 	port               string
@@ -38,6 +39,7 @@ func init() {
 	flag.BoolVar(&disableDNSTCPCheck, "disable-dns-tcp-check", false, "Disable DNS TCP check")
 	flag.StringVar(&hosts, "hosts", "giantswarm.io.,kubernetes.default.svc.cluster.local.", "DNS hosts to resolve")
 	flag.StringVar(&dnsService, "dns-service", "coredns", "Name of DNS service")
+	flag.StringVar(&dnsNamespace, "dns-namespace", "kube-system", "Namespace of DNS service")
 	flag.StringVar(&namespace, "namespace", "monitoring", "Namespace of net-exporter service")
 	flag.StringVar(&ntpServers, "ntp-servers", "0.flatcar.pool.ntp.org,1.flatcar.pool.ntp.org", "NTP servers to use for time synchronization")
 	flag.StringVar(&port, "port", "8000", "Port of net-exporter service")
@@ -101,6 +103,7 @@ func main() {
 			DisableTCPCheck: disableDNSTCPCheck,
 			Hosts:           splitHosts,
 			Service:         dnsService,
+			Namespace:       dnsNamespace,
 		}
 
 		dnsCollector, err = dns.New(c)


### PR DESCRIPTION
The dns collector is currently hardcoded to find the coredns service in the kube-system namespace. This pr fixes this to use the dns.namespace parameter provided in values.yaml in a similar pattern to the service parameter. 