### PR TITLE
Update docker-kubectl to 1.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Update github.com/giantswarm/micrologger to v1.0.0
 - Update github.com/miekg/dns to v1.1.50
 - Update k8s.io deps to v0.26.0
+- Update docker-kubectl to 1.25.4
 
 ## [1.12.0] - 2022-03-16
 

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -31,7 +31,7 @@ kubectl:
   image:
     registry: docker.io
     name: giantswarm/docker-kubectl
-    tag: 1.18.8
+    tag: 1.25.4
 
 daemonset:
   priorityClassName: system-node-critical


### PR DESCRIPTION
This PR bumps `docker-kubectl` to version `1.25.4`.

This version contains multiple vulnerabilities fix.