### PR TITLE
Don't push to onprem collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,31 +107,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-net-exporter-to-vsphere-app-collection
-          app_name: "net-exporter"
-          app_namespace: "monitoring"
-          app_collection_repo: "vsphere-app-collection"
-          requires:
-            - push-net-exporter-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-to-cloud-director-app-collection
-          app_name: "net-exporter"
-          app_namespace: "monitoring"
-          app_collection_repo: "cloud-director-app-collection"
-          requires:
-            - push-net-exporter-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
NetExporter is part of default-apps-vsphere and default-apps-cloud-director. We don't need this app in collections.