### PR TITLE
cilium network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `Cilium Network Policy` to net-exporter.
+
 ### Changed
 
 - Don't push net-exporter to capa-app-collection because it's already a default app.

--- a/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
+++ b/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
@@ -15,4 +15,7 @@ spec:
         - kube-apiserver
         - cluster
         - world
+  ingress:
+    - fromEntites:
+        - cluster
 {{ end }}

--- a/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
+++ b/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.name }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+        - world
+{{ end }}

--- a/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
+++ b/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
@@ -13,5 +13,6 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+        - cluster
         - world
 {{ end }}

--- a/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
+++ b/helm/net-exporter/templates/ciliumnetworkpolicy.yaml
@@ -12,10 +12,10 @@ spec:
       {{- include "labels.selector" . | nindent 6 }}
   egress:
     - toEntities:
-        - kube-apiserver
-        - cluster
-        - world
+       - kube-apiserver
+       - cluster
+       - world
   ingress:
-    - fromEntites:
-        - cluster
+    - fromEntities:
+       - cluster
 {{ end }}

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -46,3 +46,6 @@ NetExporter:
   DNSCheck:
     TCP:
       Disabled: false
+
+ciliumNetworkPolicy:
+  enabled: false


### PR DESCRIPTION
When switching to cilium, we lost support for defining network policies that define CIDRs as targets, such as the one we use in this app to allow egress to the API server.
This PR adds a ciliumnetworkpolicy (disabled by default, enabled by `cluster-operator` in vintage clusters) to overcome this cilium limitation.

See https://github.com/giantswarm/giantswarm/issues/23014#issuecomment-1476207008