### PR TITLE
Enable readOnlyRootFS in securityContext for daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enable readOnlyRootFilesystem in securityContext (#)[].
+- Update module google.golang.org/grpc to v1.65.0 (#373).
+- Update k8s modules to v0.30.2 (#375).
+- Update quay.io/giantswarm/alpine Docker tag to v3.20.1 (#372).
+
 ## [1.20.0] - 2024-06-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Enable readOnlyRootFilesystem in securityContext (#)[].
+- Enable readOnlyRootFilesystem in securityContext (#376)[https://github.com/giantswarm/net-exporter/pull/376].
 - Update module google.golang.org/grpc to v1.65.0 (#373).
 - Update k8s modules to v0.30.2 (#375).
 - Update quay.io/giantswarm/alpine Docker tag to v3.20.1 (#372).

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -78,6 +78,7 @@ podSecurityContext:
     type: RuntimeDefault
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Towards https://github.com/giantswarm/giantswarm/issues/31184