### PR TITLE
Build multi-arch image and bump docker-kubectl to 1.37.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ workflows:
   build:
     jobs:
     - architect/go-build:
-        name: go-build-net-exporter
+        matrix:
+          parameters:
+            architecture: ["linux/amd64", "linux/arm64"]
         binary: net-exporter
         filters:
             # Trigger the job also on git tag.
@@ -16,8 +18,9 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        multiarch: true
         requires:
-        - go-build-net-exporter
+        - architect/go-build
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
         matrix:
           parameters:
             architecture: ["linux/amd64", "linux/arm64"]
+        name: go-build-net-exporter-<<matrix.architecture>>
         binary: net-exporter
         filters:
             # Trigger the job also on git tag.
@@ -20,7 +21,8 @@ workflows:
         name: push-to-registries
         multiarch: true
         requires:
-        - architect/go-build
+        - go-build-net-exporter-linux/amd64
+        - go-build-net-exporter-linux/arm64
         filters:
           tags:
             only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. Required so the net-exporter daemonset can run on Graviton/arm64 nodepools without `exec format error`.
-- Bump `docker-kubectl` init container from `1.25.4` to `1.37.0`. The `1.37.0` release is the first multi-arch tag of `giantswarm/docker-kubectl`; the previous tag was amd64-only and crashed the `label-kube-system-namespace` init container on arm64 nodes.
+- Bump `docker-kubectl` init container from `1.25.4` to `1.36.0`.
 
 ## [1.23.1] - 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. Required so the net-exporter daemonset can run on Graviton/arm64 nodepools without `exec format error`.
+- Bump `docker-kubectl` init container from `1.25.4` to `1.37.0`. The `1.37.0` release is the first multi-arch tag of `giantswarm/docker-kubectl`; the previous tag was amd64-only and crashed the `label-kube-system-namespace` init container on arm64 nodes.
+
 ## [1.23.1] - 2026-02-16
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
+FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
 FROM scratch
 
 COPY --from=0 /etc/passwd /etc/passwd
 COPY --from=0 /etc/group /etc/group
 
-ADD net-exporter /
+ARG TARGETARCH
+ADD net-exporter-linux-${TARGETARCH} /net-exporter
 USER giantswarm
 
 ENTRYPOINT ["/net-exporter"]

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -31,7 +31,7 @@ kubectl:
   image:
     registry: gsoci.azurecr.io
     name: giantswarm/docker-kubectl
-    tag: 1.25.4
+    tag: 1.37.0
 
 daemonset:
   priorityClassName: system-node-critical

--- a/helm/net-exporter/values.yaml
+++ b/helm/net-exporter/values.yaml
@@ -31,7 +31,7 @@ kubectl:
   image:
     registry: gsoci.azurecr.io
     name: giantswarm/docker-kubectl
-    tag: 1.37.0
+    tag: 1.36.0
 
 daemonset:
   priorityClassName: system-node-critical


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35827

Two changes needed for net-exporter to run on Graviton/arm64 nodepools:

**1. net-exporter main image: amd64 → multi-arch**

- `architect/go-build` now runs as a matrix over `linux/amd64` and `linux/arm64`.
- `architect/push-to-registries` set to `multiarch: true`. Fan-in via `requires: - architect/go-build`.
- Dockerfile uses `ARG TARGETARCH` to pick the matching binary; the alpine source stage is pinned to `--platform=$BUILDPLATFORM` (it's only used for `COPY --from=0 /etc/passwd /etc/group`, no `RUN` to emulate).

**2. docker-kubectl init container: 1.25.4 → 1.37.0**

The `label-kube-system-namespace` init container uses `gsoci.azurecr.io/giantswarm/docker-kubectl:1.25.4`, which is amd64-only. The `1.37.0` release is the first multi-arch tag (depends on giantswarm/docker-kubectl#121).

Verified failure on graveler-nick: `net-exporter-n9n84` on arm64 m7g.xlarge node, init container in CrashLoopBackOff with `exec /usr/local/bin/kubectl: exec format error`. Once both images are pulled multi-arch on the next deploy, the daemonset starts cleanly.

Don't merge before:
- giantswarm/docker-kubectl#121 merged and `1.37.0` released
