### PR TITLE
Migrate go-build to architectures param and fix push-to-registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,14 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.0.2
+  architect: giantswarm/architect@8.1.0
 
 workflows:
   build:
     jobs:
     - architect/go-build:
-        matrix:
-          parameters:
-            architecture: ["linux/amd64", "linux/arm64"]
-        name: go-build-net-exporter-<<matrix.architecture>>
+        name: go-build-net-exporter
         binary: net-exporter
+        architectures: "linux/amd64,linux/arm64"
         filters:
             # Trigger the job also on git tag.
           tags:
@@ -19,10 +17,10 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        image: giantswarm/net-exporter
         multiarch: true
         requires:
-        - go-build-net-exporter-linux/amd64
-        - go-build-net-exporter-linux/arm64
+        - go-build-net-exporter
         filters:
           tags:
             only: /^v.*/


### PR DESCRIPTION
- Switch from matrix go-build to single job with architectures param so
  .platforms is written and auto-derived by push-to-registries
- Add missing image: giantswarm/net-exporter to push-to-registries
- Bump architect orb 8.0.2 → 8.1.0


Following https://gigantic.slack.com/archives/C04TGHDEF/p1779106046934269