### PR TITLE
refactor: apply go fix modernizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `interface{}` with `any` and use for-range over integers (Go modernization).
+
 ## [1.24.0] - 2026-05-10
 
 ### Changed

--- a/endpoints/blackbox.go
+++ b/endpoints/blackbox.go
@@ -29,13 +29,13 @@ type Blackbox struct {
 }
 
 func (b *Blackbox) Decoder() kithttp.DecodeRequestFunc {
-	return func(ctx context.Context, r *http.Request) (interface{}, error) {
+	return func(ctx context.Context, r *http.Request) (any, error) {
 		return nil, nil
 	}
 }
 
 func (b *Blackbox) Encoder() kithttp.EncodeResponseFunc {
-	return func(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	return func(ctx context.Context, w http.ResponseWriter, response any) error {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, err := w.Write([]byte("ok"))
 		return microerror.Mask(err)
@@ -43,7 +43,7 @@ func (b *Blackbox) Encoder() kithttp.EncodeResponseFunc {
 }
 
 func (b *Blackbox) Endpoint() kitendpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
+	return func(ctx context.Context, request any) (any, error) {
 		return nil, nil
 	}
 }

--- a/network/network.go
+++ b/network/network.go
@@ -282,7 +282,7 @@ func (c *Collector) calculateNeighbours(n int, ip string, addresses []string) []
 		n = len(addresses)
 	}
 
-	for i := 0; i < len(addresses); i++ {
+	for i := range addresses {
 		if addresses[i] == ip {
 			for j := 1; j < n+1; j++ {
 				k := i + j


### PR DESCRIPTION
## Summary

- Replace `interface{}` with `any` in `endpoints/blackbox.go`
- Replace 3-clause `for` loop with `for-range` in `network/network.go`

Applied automatically via `go fix ./...` using Go 1.26's built-in modernization fixers (`any` and `rangeint` analyzers).