### PR TITLE
ci: upgrade architect-orb to v9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.3.0
+  architect: giantswarm/architect@9.0.0
 
 workflows:
   build:
@@ -19,7 +19,6 @@ workflows:
         context: architect
         name: push-to-registries
         image: giantswarm/net-exporter
-        multiarch: true
         requires:
         - go-build-net-exporter
         filters:


### PR DESCRIPTION
## Summary

- Bumps `giantswarm/architect` orb from `8.3.0` to `9.0.0`
- Removes `multiarch: true` from `push-to-registries` (the job always uses buildx in v9)
- Dockerfile already complies with v9 multi-arch requirements (uses `TARGETARCH` with pre-built binaries, no `RUN` steps)

## Test plan

- [ ] CI passes on this branch
- [ ] Image is built and pushed for both `linux/amd64` and `linux/arm64`