### PR TITLE
feat: declare chart audience and managed metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `keywords` to `Chart.yaml`.
+- Add the `io.giantswarm.application.audience` (`all`) and `io.giantswarm.application.managed`
+  (`"true"`) annotations to `Chart.yaml`, completing the chart metadata standard for this chart.
+  `all` because net-exporter runs on customer workload clusters and is documented as a default app;
+  `"true"` because Giant Swarm operates it, with alerting rules and a runbook. As a consequence the
+  chart will be published to the Backstage chart catalog, alongside the other Cabbage cluster apps.
 
 ## [1.24.0] - 2026-05-10
 

--- a/helm/net-exporter/Chart.yaml
+++ b/helm/net-exporter/Chart.yaml
@@ -11,4 +11,6 @@ keywords:
   - observability
 annotations:
   config.giantswarm.io/version: 1.x.x
+  io.giantswarm.application.audience: all
+  io.giantswarm.application.managed: "true"
   io.giantswarm.application.team: "cabbage"


### PR DESCRIPTION
## What

Adds the two `Chart.yaml` annotations that #580 deliberately left out:

```yaml
io.giantswarm.application.audience: all
io.giantswarm.application.managed: "true"
```

Both are **REQUIRED** by the [chart metadata standard](https://docs.giantswarm.io/reference/platform-api/chart-metadata/) for a chart whose `type` is unset (i.e. `application`). With these, net-exporter is fully compliant: `apiVersion: v2`, `description`, `home`, `keywords`, `values.schema.json` and `team` are all already in place after #580.

## Why these values

**`audience: all`** — the standard defines `all` as "the application is for everyone, including Giant Swarm customers" and `giantswarm` as "built for Giant Swarm internal purposes, not to be used by customers". net-exporter runs on customer workload clusters, ships to `default-catalog`, is `netExporter.enable: true` by default in `cluster-aws`, and is listed publicly in the [default apps table](https://docs.giantswarm.io/tutorials/fleet-management/app-platform/configuring-default-apps/). It is not an internal-purposes app.

Cabbage's structurally identical charts already agree — `coredns-app`, `k8s-dns-node-cache-app`, `cilium-servicemonitors-app` and `coredns-extensions-app` are all `audience: "all"`.

**`managed: "true"`** — the standard defines this as "whether Giant Swarm is responsible for operating the application". We are: there are alerting rules in `prometheus-rules` (`kaas/tenet/alerting-rules/net-exporter.rules.yml`, and Cabbage's `platform/cabbage/alerting-rules/internet-egress.rules.yml`) and a team-cabbage-owned [runbook](https://intranet.giantswarm.io/docs/support-and-ops/runbooks/network-error/), and the chart already ships `priorityClassName: system-node-critical` and `serviceType: managed`.

Worth being explicit: **omitting `managed` is not neutral.** The standard defines absence as `false` — "customers deploying the application are responsible for operating it" — which is wrong for this chart. That is the one point where this diverges from Cabbage's current habit of setting `audience` and skipping `managed`; that omission looks like incomplete adoption rather than a deliberate `false`.

The value is quoted because the standard requires annotation values to be strings, and bare `true` is a YAML boolean.

## The side effect, stated plainly

`backstage-catalog-importer`'s `charts` command excludes any chart whose `audience` is absent or not `all` (`cmd/charts/charts.go:379-406`, a hard filter). So this change **newly publishes net-exporter to the Backstage chart catalog**, and adds the `helmchart-audience-all` tag in the components catalog.

That is the intended outcome rather than a side effect to absorb: `coredns-app` and `k8s-dns-node-cache-app` are already there, and net-exporter was the outlier for being absent. It takes effect on the next chart release, not on merge.

## What does not change

`_helpers.tpl:17` is the only `.Chart.Annotations` lookup in the chart and it reads `team` only, so nothing rendered changes.

`config.giantswarm.io/version` stays. It belongs to config-controller, is not part of the chart metadata standard, and #580 already made that call.

## Testing

- `helm lint helm/net-exporter` — clean, 0 charts failed.
- `helm template` before vs after — **byte-for-byte identical** (`diff` clean).
- `yq '... | type'` on both new values — `!!str` for each, so `managed` is the string `"true"` and not a boolean.
- `yamllint -c .yamllint.yaml` on `Chart.yaml` — clean.
